### PR TITLE
Require libgdal-core instead of libgdal+

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -34,7 +34,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -34,7 +34,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -34,7 +34,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -34,7 +34,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -34,7 +34,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -30,7 +30,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -20,7 +20,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -20,7 +20,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -20,7 +20,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -20,7 +20,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -20,7 +20,7 @@ harfbuzz:
 - '9'
 libcurl:
 - '8'
-libgdal:
+libgdal_core:
 - '3.9'
 libiconv:
 - '1'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     - patches/0056-mapcompositingfilter.c-PCRE2-related-fix.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # Presently libmapserver.so.2 is linked to libmapserver.so.x.y.z
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
@@ -53,7 +53,7 @@ requirements:
     - harfbuzz
     - libjpeg-turbo
     - libcurl
-    - libgdal
+    - libgdal-core
     - libiconv
     - libpng
     - libpq
@@ -75,7 +75,7 @@ requirements:
     - harfbuzz
     - libjpeg-turbo
     - libcurl
-    - libgdal
+    - libgdal-core
     - libiconv
     - libpng
     - libxml2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Let's only require `libgdal-core`. This should cut down the number of direct dependencies that `mapserver` has significantly. If users wish to have more advanced features of GDAL, they'll need to pull them in specifically as part of their environment creation. They can find out the package names available to do so at https://gdal.org/download.html#conda 
