### PR TITLE
Add MSSQL2008 plugin to build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -36,6 +36,7 @@ cmake -G "Ninja" %CMAKE_ARGS%                        ^
     -DWITH_JAVA=0                                    ^
     -DWITH_JPEG=1                                    ^
     -DWITH_LIBXML2=1                                 ^
+    -DWITH_MSSQL2008=1                               ^
     -DWITH_MYSQL=1                                   ^
     -DWITH_ORACLESPATIAL=0                           ^
     -DWITH_PERL=0                                    ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,6 +32,7 @@ cmake                                                \
     -DWITH_JAVA=0                                    \
     -DWITH_JPEG=1                                    \
     -DWITH_LIBXML2=1                                 \
+    -DWITH_MSSQL2008=1                               \
     -DWITH_MYSQL=1                                   \
     -DWITH_ORACLESPATIAL=0                           \
     -DWITH_PERL=0                                    \


### PR DESCRIPTION
Following the changes in MapServer in https://github.com/MapServer/MapServer/pull/7287 the MSSQL plugin now works for both Windows and Linux. 

There have been previous discussions about plugins in https://github.com/conda-forge/mapserver-feedstock/pull/56. The Oracle plugin requires an SDK to build, but the MSSQL plugin does not., so there are no additional dependencies to install. MSSQL is already part of the https://github.com/conda-forge/gdal-feedstock/ Conda package. 

I'm unsure if `unixodbc-dev` needs to be added to the build dependencies for Linux (it is not in GDAL), and still working on trying to build this locally. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
