### PR TITLE
Add vector tile support for Windows

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.12.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_python3.13.____cp313.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -26,8 +26,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -16,8 +16,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -16,8 +16,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -16,8 +16,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -16,8 +16,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -16,8 +16,6 @@ geos:
 - 3.13.1
 giflib:
 - '5.2'
-harfbuzz:
-- 11.0.1
 libcurl:
 - '8'
 libgdal_core:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -46,7 +46,7 @@ cmake -G "Ninja" %CMAKE_ARGS%                        ^
     -DWITH_POSTGIS=1                                 ^
     -DWITH_POSTGRESQL=1                              ^
     -DWITH_PROJ=1                                    ^
-    -DWITH_PROTOBUFC=0                               ^
+    -DWITH_PROTOBUFC=1                               ^
     -DWITH_PYTHON=1                                  ^
     -DWITH_RSVG=0                                    ^
     -DWITH_SOS=1                                     ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/0002-support-setting-PROTOBUF_PROTOC_EXECUTABLE-for-cross.patch
 
 build:
-  number: 6
+  number: 7
   run_exports:
     # Presently libmapserver.so.2 is linked to libmapserver.so.x.y.z
     - {{ pin_subpackage(name, max_pin='x.x.x') }}


### PR DESCRIPTION
Adds [MVT](https://mapserver.org/output/tile_mode.html#mapbox-vector-tile-mvt-output) support for Windows builds. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.
