### PR TITLE
Fix: FastCGI CMake args on Unix

### DIFF
--- a/.ci_support/migrations/mysql_devel95.yaml
+++ b/.ci_support/migrations/mysql_devel95.yaml
@@ -1,9 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for mysql_devel 9.5
-  kind: version
-  migration_number: 1
-
-mysql_devel:
-- '9.5'
-migrator_ts: 1767031156.000000

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,7 +24,6 @@ cmake -G "Ninja" %CMAKE_ARGS%                        ^
     -DWITH_CSHARP=0                                  ^
     -DWITH_CURL=1                                    ^
     -DWITH_EXEMPI=0                                  ^
-    -DWITH_FASTCGI=0                                 ^
     -DWITH_FCGI=1                                    ^
     -DWITH_FREETYPE=1                                ^
     -DWITH_FRIBIDI=1                                 ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,8 +20,7 @@ cmake                                                \
     -DWITH_CSHARP=0                                  \
     -DWITH_CURL=1                                    \
     -DWITH_EXEMPI=0                                  \
-    -DWITH_FASTCGI=1                                 \
-    -DWITH_FCGI=0                                    \
+    -DWITH_FCGI=1                                    \
     -DWITH_FREETYPE=1                                \
     -DWITH_FRIBIDI=1                                 \
     -DWITH_GDAL=1                                    \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: af1f6d7b6b4361d7b0305b4ea1869e33fa49a721bbc0e28e13dd015952dfd902
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # Presently libmapserver.so.2 is linked to libmapserver.so.x.y.z
     - {{ pin_subpackage(name, max_pin='x.x.x') }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@conda-forge-admin please rerender

I don't believe `WITH_FASTCGI` is a valid CMake argument.  Additionally, linux build logs show
```
FastCGI: disabled
WARNING (mapserver): dso library package conda-forge/linux-64::fcgi2==2.4.7=hb700be7_0 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to `build/ignore_run_exports`)
```